### PR TITLE
Client should emit an 'error' event on websocket error

### DIFF
--- a/client.js
+++ b/client.js
@@ -31,6 +31,7 @@ var Client = module.exports = function(uri, opts, cb) {
   this.conn = new WebSocket('ws://'+this.uri);
   this.conn.onopen = function() { self.emit('connect'); }
   this.conn.onmessage = this.onMessage.bind(this);
+  this.conn.onerror = function(err) { self.emit('error', err); }
 };
 util.inherits(Client, EventEmitter);
 


### PR DESCRIPTION
Otherwise, the error will bubble up, which is usually bad.

I forgot to make this PR. This is pretty important for webcoin because, otherwise, an error will be thrown if any one of the web seeds can't be reached.
